### PR TITLE
WIP: Add export command to export to Markdown files

### DIFF
--- a/src/cli.yml
+++ b/src/cli.yml
@@ -49,3 +49,5 @@ subcommands:
             index: 1
   - tags:
       about: Show tags
+  - export:
+      about: Export notes.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,10 @@ use libcub::constants::find_db;
 use libcub::note::NoteStatus;
 use libcub::{connect_to_db, find_note_by_id, list_notes, list_tags};
 
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::Path;
+
 fn main() {
     env_logger::init();
     let yaml = load_yaml!("cli.yml");
@@ -86,6 +90,14 @@ fn main() {
 
         let note = find_note_by_id(&conn, note_id).unwrap();
         writeln!(t, "{}", note.text.unwrap_or_else(|| String::from("N/A"))).unwrap();
+    } else if let Some(matches) = matches.subcommand_matches("export") {
+        let filters = parse_filters(matches);
+        let limit = parse_limit(matches);
+        let sort = parse_sort(matches);
+        let tags = parse_tags(matches);
+        let notes = list_notes(&conn, &filters, &sort, &tags, &limit).unwrap();
+
+        writeln!(t, "Exported {} notes to Markdown files.", notes.len()).unwrap();
     } else if matches.subcommand_matches("tags").is_some() {
         for tag in list_tags(&conn).unwrap() {
             writeln!(t, "{}", tag.title).unwrap();

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -53,3 +53,12 @@ fn test_list_notes() {
     let notes = list_notes(&conn, &[], &SortOrder::Title, &[], &Limit::INFINITE).unwrap();
     assert_eq!(notes.len(), 2);
 }
+
+// #[test]
+// fn test_export_notes() {
+//     let conn = Connection::open_in_memory().unwrap();
+//     bootstrap(&conn);
+
+//     let notes = list_notes(&conn, &[], &SortOrder::Title, &[], &Limit::INFINITE).unwrap();
+//     assert_eq!(notes.len(), 2);
+// }


### PR DESCRIPTION
I'd like to extend `cub` to support an `export` command and export the notes to Markdown files. I have a [working prototype of this in Ruby](https://github.com/jessmartin/bear-sqlite-to-md) already, but this Rust implementation seems like a great place to build out that functionality that already has a CLI distribution path built in.

This is my first time with Rust, but it's a pretty clean and simple language!